### PR TITLE
(MODULES-7814) Ignore nil values when parsing commands. Fix for: Could not evaluate: undefined method strip! for nil:NilClass

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -79,8 +79,9 @@ Puppet::Type.type(:augeas).provide(:augeas) do
     data = data.flatten
     args = []
     data.each do |line|
+      next if line.nil?
       line.strip!
-      next if line.nil? || line.empty?
+      next if line.empty?
       argline = []
       sc = StringScanner.new(line)
       cmd = sc.scan(%r{\w+|==|!=})

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -46,6 +46,16 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
   end
 
   describe 'command parsing' do
+    it 'ignores nil values when parsing commands' do
+      commands = [nil, 'set Jar/Jar Binks']
+      tokens = provider.parse_commands(commands)
+      expect(tokens.size).to eq(1)
+      expect(tokens[0].size).to eq(3)
+      expect(tokens[0][0]).to eq('set')
+      expect(tokens[0][1]).to eq('Jar/Jar')
+      expect(tokens[0][2]).to eq('Binks')
+    end
+
     it 'breaks apart a single line into three tokens and clean up the context' do
       resource[:context] = '/context'
       tokens = provider.parse_commands('set Jar/Jar Binks')


### PR DESCRIPTION
While investigating an issue for a nightly build we came across this error:
`Error: /Stage[main]/Main/Tomcat::Config::Server[tomcat8-jsvc]/Augeas[server-/opt/apache-tomcat/tomcat8-jsvc]: Could not evaluate: undefined method "strip!" for nil:NilClass`
After making this modification locally first and running the tests again, everything works fine. 
There was already a logic in place to check whether the data was nil or not, however this should have been evaluated before the strip operation.