### PR TITLE
(MODULES-8014) relatively require helper code

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -18,7 +18,7 @@ require 'strscan'
 require 'puppet/util'
 require 'puppet/util/diff'
 require 'puppet/util/package'
-require 'puppet_x/augeas/util/parser'
+require_relative '../../../puppet_x/augeas/util/parser'
 
 Puppet::Type.type(:augeas).provide(:augeas) do
   include Puppet::Util


### PR DESCRIPTION
Prior to this commit, when the augeas_core module was installed via
`puppet module install`, the helper code loaded came from the vendored
module rather than the installed module. Moving the `require` to
`require_relative` fixes that.