### PR TITLE
(MODULES-7397) Load Augeas lenses from modules

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -367,8 +367,18 @@ Puppet::Type.type(:augeas).provide(:augeas) do
       load_path.flatten!
     end
 
-    if Puppet::FileSystem.exist?("#{Puppet[:libdir]}/augeas/lenses")
-      load_path << "#{Puppet[:libdir]}/augeas/lenses"
+    if Puppet::Application.name == :agent
+      if Puppet::FileSystem.exist?("#{Puppet[:libdir]}/augeas/lenses")
+        load_path << "#{Puppet[:libdir]}/augeas/lenses"
+      end
+    else
+      env = Puppet.lookup(:current_environment)
+      env.each_plugin_directory do |dir|
+        lenses = File.join(dir, 'augeas', 'lenses')
+        if File.exist?(lenses)
+          load_path << lenses
+        end
+      end
     end
 
     load_path.join(':')


### PR DESCRIPTION
When creating the load path for Augeas, the module directories are now also searched for lenses and their folder path is added accordingly. This happens in every context except `agent` application. Through plugin syncing (and later cached lenses) it does not need these extra paths.