### PR TITLE
(maint) Release prep for 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org).
 
-## [1.1.0](https://github.com/puppetlabs/puppetlabs-augeas_core/tree/1.1.0) (2020-09-28)
+## [1.1.1](https://github.com/puppetlabs/puppetlabs-augeas_core/tree/1.1.1) (2020-09-29)
+
+[Full Changelog](https://github.com/puppetlabs/puppetlabs-augeas_core/compare/1.1.0...1.1.1)
+
+### Fixed
+
+- \(maint\) Readd puppet-blacksmith dependency [\#30](https://github.com/puppetlabs/puppetlabs-augeas_core/pull/30) ([GabrielNagy](https://github.com/GabrielNagy))
+
+## [1.1.0](https://github.com/puppetlabs/puppetlabs-augeas_core/tree/1.1.0) (2020-09-29)
 
 [Full Changelog](https://github.com/puppetlabs/puppetlabs-augeas_core/compare/1.0.5...1.1.0)
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-augeas_core",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "puppetlabs",
   "summary": "Manage files using Augeas",
   "license": "Apache-2.0",


### PR DESCRIPTION
Tag 1.1.0 was never pushed to the forge due to a missing dependency for the release job, see https://github.com/puppetlabs/puppetlabs-augeas_core/pull/30.