### PR TITLE
(maint) Add PDK dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :system_tests do
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1.0')
+  gem "pdk", '~> 1.18',                                                          platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
It appears that PDK is now needed to use the module:push task from
puppet-blacksmith. Add it as a dependency.