### PR TITLE
(MODULES-10950) Infer application name from run mode

### DIFF
--- a/lib/puppet/provider/augeas/augeas.rb
+++ b/lib/puppet/provider/augeas/augeas.rb
@@ -367,7 +367,7 @@ Puppet::Type.type(:augeas).provide(:augeas) do
       load_path.flatten!
     end
 
-    if Puppet::Application.name == :agent
+    if Puppet.run_mode.name == :agent
       if Puppet::FileSystem.exist?("#{Puppet[:libdir]}/augeas/lenses")
         load_path << "#{Puppet[:libdir]}/augeas/lenses"
       end

--- a/metadata.json
+++ b/metadata.json
@@ -14,50 +14,60 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+        "16.04",
+        "18.04",
+        "20.04"
       ]
     },
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "25"
+        "30",
+        "31",
+        "32"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.14.0",

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -1124,7 +1124,7 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
     context 'when running application is agent' do
       before(:each) do
         Puppet[:libdir] = my_fixture_dir
-        Puppet::Application.stubs(:name).returns(:agent)
+        Puppet.run_mode.stubs(:name).returns(:agent)
       end
 
       it 'offers pluginsync augeas/lenses subdir' do
@@ -1139,7 +1139,7 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
 
     context 'when running application is not agent' do
       before(:each) do
-        Puppet::Application.stubs(:name).returns(:apply)
+        Puppet.run_mode.stubs(:name).returns(:user)
 
         env = Puppet::Node::Environment.create('root', ['/modules/foobar'])
         Puppet.stubs(:lookup).returns(env)


### PR DESCRIPTION
Fix a regression introduced by [MODULES-7397](https://github.com/puppetlabs/puppetlabs-augeas_core/pull/27) which incorrectly assumed that the application name can be queried through
`Puppet::Application.name`, causing lenses that are pluginsynced not to be loaded.

Since we only need to find out whether or not we're running as part of `puppet agent`, it should be enough to use `Puppet.run_mode.name`, which returns `:agent` in this case, and `:user` otherwise.
