### PR TITLE
(MODULES-10953) Update metadata.json and pdk version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,56 +12,25 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
+      "operatingsystem": "CentOS"
     },
     {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
+      "operatingsystem": "OracleLinux"
     },
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
+      "operatingsystem": "RedHat"
     },
     {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
+      "operatingsystem": "Scientific"
     },
     {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "8",
-        "9",
-        "10"
-      ]
+      "operatingsystem": "Debian"
     },
     {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04",
-        "18.04",
-        "20.04"
-      ]
+      "operatingsystem": "Ubuntu"
     },
     {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "30",
-        "31",
-        "32"
-      ]
+      "operatingsystem": "Fedora"
     }
   ],
   "requirements": [

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ default_facts.each do |fact, value|
 end
 
 RSpec.configure do |c|
+  c.mock_with :rspec
   c.default_facts = default_facts
   c.before :each do
     # set to strictest setting for testing

--- a/spec/unit/provider/augeas/augeas_spec.rb
+++ b/spec/unit/provider/augeas/augeas_spec.rb
@@ -211,10 +211,10 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
   end
 
   describe 'get filters' do
-    let(:augeas) { stub('augeas', get: 'value') }
+    let(:augeas) { instance_double('Augeas', get: 'value') }
 
     before(:each) do
-      augeas.stubs('close')
+      allow(augeas).to receive('close')
       provider.aug = augeas
     end
 
@@ -240,11 +240,11 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
   end
 
   describe 'values filters' do
-    let(:augeas) { stub('augeas', match: ['set', 'of', 'values']) }
+    let(:augeas) { instance_double('Augeas', match: ['set', 'of', 'values']) }
 
     before(:each) do
-      augeas.stubs(:get).returns('set').then.returns('of').then.returns('values')
-      augeas.stubs('close')
+      allow(augeas).to receive(:get).and_return('set', 'of', 'values')
+      allow(augeas).to receive('close')
       provider.aug = augeas
     end
 
@@ -278,8 +278,8 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
     end
 
     it 'returns true for an array match with internally escaped single quotes' do
-      provider.aug.stubs(:match).returns(['set', "o'values", 'here'])
-      provider.aug.stubs(:get).returns('set').then.returns("o'values").then.returns('here')
+      allow(provider.aug).to receive(:match).and_return(['set', "o'values", 'here'])
+      allow(provider.aug).to receive(:get).and_return('set', "o'values", 'here')
       command = ['values', 'fake value', "== [ 'set', 'o\\'values', 'here']"]
       expect(provider.process_values(command)).to eq(true)
     end
@@ -310,8 +310,8 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
     end
 
     it 'returns true for an array match with literal backslashes' do
-      provider.aug.stubs(:match).returns(['set', 'o\\values', 'here'])
-      provider.aug.stubs(:get).returns('set').then.returns('o\\values').then.returns('here')
+      allow(provider.aug).to receive(:match).and_return(['set', 'o\\values', 'here'])
+      allow(provider.aug).to receive(:get).and_return('set', 'o\\values', 'here')
       command = ['values', 'fake value', '== [ "set", "o\\\\values", "here"]']
       expect(provider.process_values(command)).to eq(true)
     end
@@ -337,18 +337,18 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
     end
 
     it 'returns true for an empty array match' do
-      provider.aug.stubs(:match).returns([])
-      provider.aug.stubs(:get)
+      allow(provider.aug).to receive(:match).and_return([])
+      allow(provider.aug).to receive(:get)
       command = ['values', 'fake value', '== []']
       expect(provider.process_values(command)).to eq(true)
     end
   end
 
   describe 'match filters' do
-    let(:augeas) { stub('augeas', match: ['set', 'of', 'values']) }
+    let(:augeas) { instance_double('Augeas', match: ['set', 'of', 'values']) }
 
     before(:each) do
-      augeas.stubs('close')
+      allow(augeas).to receive('close')
       provider.aug = augeas
     end
 
@@ -414,62 +414,62 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
   end
 
   describe 'need to run' do
-    let(:augeas) { stub('augeas') }
+    let(:augeas) { instance_double('Augeas') }
 
     before(:each) do
-      augeas.stubs('close')
+      allow(augeas).to receive('close')
       provider.aug = augeas
 
       # These tests pretend to be an earlier version so the provider doesn't
       # attempt to make the change in the need_to_run? method
-      provider.stubs(:get_augeas_version).returns('0.3.5')
+      allow(provider).to receive(:get_augeas_version).and_return('0.3.5')
     end
 
     it 'handles no filters' do
-      augeas.stubs('match').returns(['set', 'of', 'values'])
+      allow(augeas).to receive('match').and_return(['set', 'of', 'values'])
       expect(provider.need_to_run?).to eq(true)
     end
 
     it 'returns true when a get filter matches' do
       resource[:onlyif] = 'get path == value'
-      augeas.stubs('get').returns('value')
+      allow(augeas).to receive('get').and_return('value')
       expect(provider.need_to_run?).to eq(true)
     end
 
     describe 'performing numeric comparisons (#22617)' do
       it 'returns true when a get string compare is true' do
         resource[:onlyif] = 'get bpath > a'
-        augeas.stubs('get').returns('b')
+        allow(augeas).to receive('get').and_return('b')
         expect(provider.need_to_run?).to eq(true)
       end
 
       it 'returns false when a get string compare is false' do
         resource[:onlyif] = 'get a19path > a2'
-        augeas.stubs('get').returns('a19')
+        allow(augeas).to receive('get').and_return('a19')
         expect(provider.need_to_run?).to eq(false)
       end
 
       it 'returns true when a get int gt compare is true' do
         resource[:onlyif] = 'get path19 > 2'
-        augeas.stubs('get').returns('19')
+        allow(augeas).to receive('get').and_return('19')
         expect(provider.need_to_run?).to eq(true)
       end
 
       it 'returns true when a get int ge compare is true' do
         resource[:onlyif] = 'get path19 >= 2'
-        augeas.stubs('get').returns('19')
+        allow(augeas).to receive('get').and_return('19')
         expect(provider.need_to_run?).to eq(true)
       end
 
       it 'returns true when a get int lt compare is true' do
         resource[:onlyif] = 'get path2 < 19'
-        augeas.stubs('get').returns('2')
+        allow(augeas).to receive('get').and_return('2')
         expect(provider.need_to_run?).to eq(true)
       end
 
       it 'returns false when a get int le compare is false' do
         resource[:onlyif] = 'get path39 <= 4'
-        augeas.stubs('get').returns('39')
+        allow(augeas).to receive('get').and_return('39')
         expect(provider.need_to_run?).to eq(false)
       end
     end
@@ -493,19 +493,19 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
 
     it 'returns false when a get filter does not match' do
       resource[:onlyif] = 'get path == another value'
-      augeas.stubs('get').returns('value')
+      allow(augeas).to receive('get').and_return('value')
       expect(provider.need_to_run?).to eq(false)
     end
 
     it 'returns true when a match filter matches' do
       resource[:onlyif] = 'match path size == 3'
-      augeas.stubs('match').returns(['set', 'of', 'values'])
+      allow(augeas).to receive('match').and_return(['set', 'of', 'values'])
       expect(provider.need_to_run?).to eq(true)
     end
 
     it 'returns false when a match filter does not match' do
       resource[:onlyif] = 'match path size == 2'
-      augeas.stubs('match').returns(['set', 'of', 'values'])
+      allow(augeas).to receive('match').and_return(['set', 'of', 'values'])
       expect(provider.need_to_run?).to eq(false)
     end
 
@@ -513,21 +513,21 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
     it 'setting force should not change the above logic' do
       resource[:force] = true
       resource[:onlyif] = 'match path size == 2'
-      augeas.stubs('match').returns(['set', 'of', 'values'])
+      allow(augeas).to receive('match').and_return(['set', 'of', 'values'])
       expect(provider.need_to_run?).to eq(false)
     end
 
     # Ticket 5211 testing
     it 'returns true when a size != the provided value' do
       resource[:onlyif] = 'match path size != 17'
-      augeas.stubs('match').returns(['set', 'of', 'values'])
+      allow(augeas).to receive('match').and_return(['set', 'of', 'values'])
       expect(provider.need_to_run?).to eq(true)
     end
 
     # Ticket 5211 testing
     it 'returns false when a size does equal the provided value' do
       resource[:onlyif] = 'match path size != 3'
-      augeas.stubs('match').returns(['set', 'of', 'values'])
+      allow(augeas).to receive('match').and_return(['set', 'of', 'values'])
       expect(provider.need_to_run?).to eq(false)
     end
 
@@ -543,15 +543,15 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
           resource[:context] = '/files'
           resource[:changes] = ["set #{file}/foo bar"]
 
-          File.stubs(:delete)
-          provider.stubs(:get_augeas_version).returns('0.10.0')
-          provider.stubs('diff').with(file.to_s, "#{file}.augnew").returns('diff')
+          allow(File).to receive(:delete)
+          allow(provider).to receive(:get_augeas_version).and_return('0.10.0')
+          allow(provider).to receive('diff').with(file.to_s, "#{file}.augnew").and_return('diff')
 
-          augeas.stubs(:set).returns(true)
-          augeas.stubs(:save).returns(true)
-          augeas.stubs(:match).with('/augeas/events/saved').returns(['/augeas/events/saved'])
-          augeas.stubs(:get).with('/augeas/events/saved').returns("/files#{file}")
-          augeas.stubs(:set).with('/augeas/save', 'newfile')
+          allow(augeas).to receive(:set).and_return(true)
+          allow(augeas).to receive(:save).and_return(true)
+          allow(augeas).to receive(:match).with('/augeas/events/saved').and_return(['/augeas/events/saved'])
+          allow(augeas).to receive(:get).with('/augeas/events/saved').and_return("/files#{file}")
+          allow(augeas).to receive(:set).with('/augeas/save', 'newfile')
         end
 
         if cfg && param
@@ -577,23 +577,23 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
         resource[:show_diff] = true
 
         resource[:root] = ''
-        provider.stubs(:get_augeas_version).returns('0.10.0')
-        augeas.stubs(:set).returns(true)
-        augeas.stubs(:save).returns(true)
+        allow(provider).to receive(:get_augeas_version).and_return('0.10.0')
+        allow(augeas).to receive(:set).and_return(true)
+        allow(augeas).to receive(:save).and_return(true)
       end
 
       it 'displays a diff when a single file is shown to have been changed' do
         file = '/etc/hosts'
-        File.stubs(:delete)
+        allow(File).to receive(:delete)
 
         resource[:loglevel] = 'crit'
         resource[:context] = '/files'
         resource[:changes] = ["set #{file}/foo bar"]
 
-        augeas.stubs(:match).with('/augeas/events/saved').returns(['/augeas/events/saved'])
-        augeas.stubs(:get).with('/augeas/events/saved').returns("/files#{file}")
-        augeas.expects(:set).with('/augeas/save', 'newfile')
-        provider.expects('diff').with(file.to_s, "#{file}.augnew").returns('diff')
+        allow(augeas).to receive(:match).with('/augeas/events/saved').and_return(['/augeas/events/saved'])
+        allow(augeas).to receive(:get).with('/augeas/events/saved').and_return("/files#{file}")
+        expect(augeas).to receive(:set).with('/augeas/save', 'newfile')
+        expect(provider).to receive('diff').with(file.to_s, "#{file}.augnew").and_return('diff')
 
         expect(provider).to be_need_to_run
 
@@ -604,17 +604,17 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
       it 'displays a diff for each file that is changed when changing many files' do
         file1 = '/etc/hosts'
         file2 = '/etc/resolv.conf'
-        File.stubs(:delete)
+        allow(File).to receive(:delete)
 
         resource[:context] = '/files'
         resource[:changes] = ["set #{file1}/foo bar", "set #{file2}/baz biz"]
 
-        augeas.stubs(:match).with('/augeas/events/saved').returns(['/augeas/events/saved[1]', '/augeas/events/saved[2]'])
-        augeas.stubs(:get).with('/augeas/events/saved[1]').returns("/files#{file1}")
-        augeas.stubs(:get).with('/augeas/events/saved[2]').returns("/files#{file2}")
-        augeas.expects(:set).with('/augeas/save', 'newfile')
-        provider.expects(:diff).with(file1.to_s, "#{file1}.augnew").returns("diff #{file1}")
-        provider.expects(:diff).with(file2.to_s, "#{file2}.augnew").returns("diff #{file2}")
+        allow(augeas).to receive(:match).with('/augeas/events/saved').and_return(['/augeas/events/saved[1]', '/augeas/events/saved[2]'])
+        allow(augeas).to receive(:get).with('/augeas/events/saved[1]').and_return("/files#{file1}")
+        allow(augeas).to receive(:get).with('/augeas/events/saved[2]').and_return("/files#{file2}")
+        expect(augeas).to receive(:set).with('/augeas/save', 'newfile')
+        expect(provider).to receive(:diff).with(file1.to_s, "#{file1}.augnew").and_return("diff #{file1}")
+        expect(provider).to receive(:diff).with(file2.to_s, "#{file2}.augnew").and_return("diff #{file2}")
 
         expect(provider).to be_need_to_run
 
@@ -626,16 +626,16 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
         it 'calls diff when a file is shown to have been changed' do
           root = '/tmp/foo'
           file = '/etc/hosts'
-          File.stubs(:delete)
+          allow(File).to receive(:delete)
 
           resource[:context] = '/files'
           resource[:changes] = ["set #{file}/foo bar"]
           resource[:root] = root
 
-          augeas.stubs(:match).with('/augeas/events/saved').returns(['/augeas/events/saved'])
-          augeas.stubs(:get).with('/augeas/events/saved').returns("/files#{file}")
-          augeas.expects(:set).with('/augeas/save', 'newfile')
-          provider.expects(:diff).with("#{root}#{file}", "#{root}#{file}.augnew").returns('diff')
+          allow(augeas).to receive(:match).with('/augeas/events/saved').and_return(['/augeas/events/saved'])
+          allow(augeas).to receive(:get).with('/augeas/events/saved').and_return("/files#{file}")
+          expect(augeas).to receive(:set).with('/augeas/save', 'newfile')
+          expect(provider).to receive(:diff).with("#{root}#{file}", "#{root}#{file}.augnew").and_return('diff')
 
           expect(provider).to be_need_to_run
 
@@ -650,12 +650,12 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
         resource[:context] = '/files'
         resource[:changes] = ["set #{file}/foo bar"]
 
-        augeas.stubs(:match).with('/augeas/events/saved').returns([])
-        augeas.expects(:set).with('/augeas/save', 'newfile')
-        augeas.expects(:get).with('/augeas/events/saved').never
-        augeas.expects(:close)
+        allow(augeas).to receive(:match).with('/augeas/events/saved').and_return([])
+        expect(augeas).to receive(:set).with('/augeas/save', 'newfile')
+        expect(augeas).to receive(:get).with('/augeas/events/saved').never
+        expect(augeas).to receive(:close)
 
-        provider.expects(:diff).never
+        expect(provider).to receive(:diff).never
         expect(provider).not_to be_need_to_run
       end
 
@@ -665,14 +665,14 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
         resource[:context] = '/files'
         resource[:changes] = ["set #{file}/foo bar"]
 
-        augeas.stubs(:match).with('/augeas/events/saved').returns(['/augeas/events/saved'])
-        augeas.stubs(:get).with('/augeas/events/saved').returns("/files#{file}")
-        augeas.expects(:set).with('/augeas/save', 'newfile')
-        augeas.expects(:close)
+        allow(augeas).to receive(:match).with('/augeas/events/saved').and_return(['/augeas/events/saved'])
+        allow(augeas).to receive(:get).with('/augeas/events/saved').and_return("/files#{file}")
+        expect(augeas).to receive(:set).with('/augeas/save', 'newfile')
+        expect(augeas).to receive(:close)
 
-        File.expects(:delete).with(file + '.augnew')
+        expect(File).to receive(:delete).with(file + '.augnew')
 
-        provider.expects(:diff).with(file.to_s, "#{file}.augnew").returns('')
+        expect(provider).to receive(:diff).with(file.to_s, "#{file}.augnew").and_return('')
         expect(provider).to be_need_to_run
       end
 
@@ -683,15 +683,15 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
         resource[:context] = '/files'
         resource[:changes] = ["set #{file}/foo bar"]
 
-        augeas.stubs(:match).with('/augeas/events/saved').returns(['/augeas/events/saved[1]', '/augeas/events/saved[2]'])
-        augeas.stubs(:get).with('/augeas/events/saved[1]').returns("/files#{file}")
-        augeas.stubs(:get).with('/augeas/events/saved[2]').returns("/files#{file}")
-        augeas.expects(:set).with('/augeas/save', 'newfile')
-        augeas.expects(:close)
+        allow(augeas).to receive(:match).with('/augeas/events/saved').and_return(['/augeas/events/saved[1]', '/augeas/events/saved[2]'])
+        allow(augeas).to receive(:get).with('/augeas/events/saved[1]').and_return("/files#{file}")
+        allow(augeas).to receive(:get).with('/augeas/events/saved[2]').and_return("/files#{file}")
+        expect(augeas).to receive(:set).with('/augeas/save', 'newfile')
+        expect(augeas).to receive(:close)
 
-        File.expects(:delete).with(file + '.augnew').once
+        expect(File).to receive(:delete).with(file + '.augnew').once
 
-        provider.expects(:diff).with(file.to_s, "#{file}.augnew").returns('').once
+        expect(provider).to receive(:diff).with(file.to_s, "#{file}.augnew").and_return('').once
         expect(provider).to be_need_to_run
       end
 
@@ -701,59 +701,59 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
         resource[:context] = '/files'
         resource[:changes] = ["set #{file}/foo bar"]
 
-        augeas.stubs(:save).returns(false)
-        augeas.stubs(:match).with('/augeas/events/saved').returns([])
-        augeas.expects(:close)
+        allow(augeas).to receive(:save).and_return(false)
+        allow(augeas).to receive(:match).with('/augeas/events/saved').and_return([])
+        expect(augeas).to receive(:close)
 
-        provider.expects(:diff).never
-        provider.expects(:print_put_errors)
+        expect(provider).to receive(:diff).never
+        expect(provider).to receive(:print_put_errors)
         expect { provider.need_to_run? }.to raise_error(Puppet::Error)
       end
     end
   end
 
   describe 'augeas execution integration' do
-    let(:augeas) { stub('augeas', :load) }
+    let(:augeas) { instance_double('Augeas', load: nil) }
 
     before(:each) do
-      augeas.stubs('close')
-      augeas.stubs(:match).with('/augeas/events/saved').returns([])
+      allow(augeas).to receive('close')
+      allow(augeas).to receive(:match).with('/augeas/events/saved').and_return([])
 
       provider.aug = augeas
-      provider.stubs(:get_augeas_version).returns('0.3.5')
+      allow(provider).to receive(:get_augeas_version).and_return('0.3.5')
     end
 
     it 'handles set commands' do
       resource[:changes] = 'set JarJar Binks'
       resource[:context] = '/some/path/'
-      augeas.expects(:set).with('/some/path/JarJar', 'Binks').returns(true)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:set).with('/some/path/JarJar', 'Binks').and_return(true)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'handles rm commands' do
       resource[:changes] = 'rm /Jar/Jar'
-      augeas.expects(:rm).with('/Jar/Jar')
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:rm).with('/Jar/Jar')
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'handles remove commands' do
       resource[:changes] = 'remove /Jar/Jar'
-      augeas.expects(:rm).with('/Jar/Jar')
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:rm).with('/Jar/Jar')
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'handles clear commands' do
       resource[:changes] = 'clear Jar/Jar'
       resource[:context] = '/foo/'
-      augeas.expects(:clear).with('/foo/Jar/Jar').returns(true)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:clear).with('/foo/Jar/Jar').and_return(true)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
@@ -761,20 +761,20 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
       it 'clears missing path' do
         resource[:changes] = 'touch Jar/Jar'
         resource[:context] = '/foo/'
-        augeas.expects(:match).with('/foo/Jar/Jar').returns([])
-        augeas.expects(:clear).with('/foo/Jar/Jar').returns(true)
-        augeas.expects(:save).returns(true)
-        augeas.expects(:close)
+        expect(augeas).to receive(:match).with('/foo/Jar/Jar').and_return([])
+        expect(augeas).to receive(:clear).with('/foo/Jar/Jar').and_return(true)
+        expect(augeas).to receive(:save).and_return(true)
+        expect(augeas).to receive(:close)
         expect(provider.execute_changes).to eq(:executed)
       end
 
       it 'does not change on existing path' do
         resource[:changes] = 'touch Jar/Jar'
         resource[:context] = '/foo/'
-        augeas.expects(:match).with('/foo/Jar/Jar').returns(['/foo/Jar/Jar'])
-        augeas.expects(:clear).never
-        augeas.expects(:save).returns(true)
-        augeas.expects(:close)
+        expect(augeas).to receive(:match).with('/foo/Jar/Jar').and_return(['/foo/Jar/Jar'])
+        expect(augeas).to receive(:clear).never
+        expect(augeas).to receive(:save).and_return(true)
+        expect(augeas).to receive(:close)
         expect(provider.execute_changes).to eq(:executed)
       end
     end
@@ -782,145 +782,145 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
     it 'handles ins commands with before' do
       resource[:changes] = 'ins Binks before Jar/Jar'
       resource[:context] = '/foo'
-      augeas.expects(:insert).with('/foo/Jar/Jar', 'Binks', true)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:insert).with('/foo/Jar/Jar', 'Binks', true)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'handles ins commands with after' do
       resource[:changes] = 'ins Binks after /Jar/Jar'
       resource[:context] = '/foo'
-      augeas.expects(:insert).with('/Jar/Jar', 'Binks', false)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:insert).with('/Jar/Jar', 'Binks', false)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'handles ins with no context' do
       resource[:changes] = 'ins Binks after /Jar/Jar'
-      augeas.expects(:insert).with('/Jar/Jar', 'Binks', false)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:insert).with('/Jar/Jar', 'Binks', false)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'handles multiple commands' do
       resource[:changes] = ['ins Binks after /Jar/Jar', 'clear Jar/Jar']
       resource[:context] = '/foo/'
-      augeas.expects(:insert).with('/Jar/Jar', 'Binks', false)
-      augeas.expects(:clear).with('/foo/Jar/Jar').returns(true)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:insert).with('/Jar/Jar', 'Binks', false)
+      expect(augeas).to receive(:clear).with('/foo/Jar/Jar').and_return(true)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'handles defvar commands' do
       resource[:changes] = 'defvar myjar Jar/Jar'
       resource[:context] = '/foo/'
-      augeas.expects(:defvar).with('myjar', '/foo/Jar/Jar').returns(true)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:defvar).with('myjar', '/foo/Jar/Jar').and_return(true)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'passes through augeas variables without context' do
       resource[:changes] = ['defvar myjar Jar/Jar', 'set $myjar/Binks 1']
       resource[:context] = '/foo/'
-      augeas.expects(:defvar).with('myjar', '/foo/Jar/Jar').returns(true)
+      expect(augeas).to receive(:defvar).with('myjar', '/foo/Jar/Jar').and_return(true)
       # this is the important bit, shouldn't be /foo/$myjar/Binks
-      augeas.expects(:set).with('$myjar/Binks', '1').returns(true)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:set).with('$myjar/Binks', '1').and_return(true)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'handles defnode commands' do
       resource[:changes] = 'defnode newjar Jar/Jar[last()+1] Binks'
       resource[:context] = '/foo/'
-      augeas.expects(:defnode).with('newjar', '/foo/Jar/Jar[last()+1]', 'Binks').returns(true)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:defnode).with('newjar', '/foo/Jar/Jar[last()+1]', 'Binks').and_return(true)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'handles mv commands' do
       resource[:changes] = 'mv Jar/Jar Binks'
       resource[:context] = '/foo/'
-      augeas.expects(:mv).with('/foo/Jar/Jar', '/foo/Binks').returns(true)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:mv).with('/foo/Jar/Jar', '/foo/Binks').and_return(true)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'handles rename commands' do
       resource[:changes] = 'rename Jar/Jar Binks'
       resource[:context] = '/foo/'
-      augeas.expects(:rename).with('/foo/Jar/Jar', 'Binks').returns(true)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:rename).with('/foo/Jar/Jar', 'Binks').and_return(true)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'handles setm commands' do
       resource[:changes] = ['set test[1]/Jar/Jar Foo', 'set test[2]/Jar/Jar Bar', 'setm test Jar/Jar Binks']
       resource[:context] = '/foo/'
-      augeas.expects(:respond_to?).with('setm').returns(true)
-      augeas.expects(:set).with('/foo/test[1]/Jar/Jar', 'Foo').returns(true)
-      augeas.expects(:set).with('/foo/test[2]/Jar/Jar', 'Bar').returns(true)
-      augeas.expects(:setm).with('/foo/test', 'Jar/Jar', 'Binks').returns(true)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:respond_to?).with('setm').and_return(true)
+      expect(augeas).to receive(:set).with('/foo/test[1]/Jar/Jar', 'Foo').and_return(true)
+      expect(augeas).to receive(:set).with('/foo/test[2]/Jar/Jar', 'Bar').and_return(true)
+      expect(augeas).to receive(:setm).with('/foo/test', 'Jar/Jar', 'Binks').and_return(true)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'throws error if setm command not supported' do
       resource[:changes] = ['set test[1]/Jar/Jar Foo', 'set test[2]/Jar/Jar Bar', 'setm test Jar/Jar Binks']
       resource[:context] = '/foo/'
-      augeas.expects(:respond_to?).with('setm').returns(false)
-      augeas.expects(:set).with('/foo/test[1]/Jar/Jar', 'Foo').returns(true)
-      augeas.expects(:set).with('/foo/test[2]/Jar/Jar', 'Bar').returns(true)
+      expect(augeas).to receive(:respond_to?).with('setm').and_return(false)
+      expect(augeas).to receive(:set).with('/foo/test[1]/Jar/Jar', 'Foo').and_return(true)
+      expect(augeas).to receive(:set).with('/foo/test[2]/Jar/Jar', 'Bar').and_return(true)
       expect { provider.execute_changes }.to raise_error RuntimeError, %r{command 'setm' not supported}
     end
 
     it 'handles clearm commands' do
       resource[:changes] = ['set test[1]/Jar/Jar Foo', 'set test[2]/Jar/Jar Bar', 'clearm test Jar/Jar']
       resource[:context] = '/foo/'
-      augeas.expects(:respond_to?).with('clearm').returns(true)
-      augeas.expects(:set).with('/foo/test[1]/Jar/Jar', 'Foo').returns(true)
-      augeas.expects(:set).with('/foo/test[2]/Jar/Jar', 'Bar').returns(true)
-      augeas.expects(:clearm).with('/foo/test', 'Jar/Jar').returns(true)
-      augeas.expects(:save).returns(true)
-      augeas.expects(:close)
+      expect(augeas).to receive(:respond_to?).with('clearm').and_return(true)
+      expect(augeas).to receive(:set).with('/foo/test[1]/Jar/Jar', 'Foo').and_return(true)
+      expect(augeas).to receive(:set).with('/foo/test[2]/Jar/Jar', 'Bar').and_return(true)
+      expect(augeas).to receive(:clearm).with('/foo/test', 'Jar/Jar').and_return(true)
+      expect(augeas).to receive(:save).and_return(true)
+      expect(augeas).to receive(:close)
       expect(provider.execute_changes).to eq(:executed)
     end
 
     it 'throws error if clearm command not supported' do
       resource[:changes] = ['set test[1]/Jar/Jar Foo', 'set test[2]/Jar/Jar Bar', 'clearm test Jar/Jar']
       resource[:context] = '/foo/'
-      augeas.expects(:respond_to?).with('clearm').returns(false)
-      augeas.expects(:set).with('/foo/test[1]/Jar/Jar', 'Foo').returns(true)
-      augeas.expects(:set).with('/foo/test[2]/Jar/Jar', 'Bar').returns(true)
+      expect(augeas).to receive(:respond_to?).with('clearm').and_return(false)
+      expect(augeas).to receive(:set).with('/foo/test[1]/Jar/Jar', 'Foo').and_return(true)
+      expect(augeas).to receive(:set).with('/foo/test[2]/Jar/Jar', 'Bar').and_return(true)
       expect { provider.execute_changes }.to raise_error(RuntimeError, %r{command 'clearm' not supported})
     end
 
     it 'throws error if saving failed' do
       resource[:changes] = ['set test[1]/Jar/Jar Foo', 'set test[2]/Jar/Jar Bar', 'clearm test Jar/Jar']
       resource[:context] = '/foo/'
-      augeas.expects(:respond_to?).with('clearm').returns(true)
-      augeas.expects(:set).with('/foo/test[1]/Jar/Jar', 'Foo').returns(true)
-      augeas.expects(:set).with('/foo/test[2]/Jar/Jar', 'Bar').returns(true)
-      augeas.expects(:clearm).with('/foo/test', 'Jar/Jar').returns(true)
-      augeas.expects(:save).returns(false)
-      provider.expects(:print_put_errors)
-      augeas.expects(:match).returns([])
+      expect(augeas).to receive(:respond_to?).with('clearm').and_return(true)
+      expect(augeas).to receive(:set).with('/foo/test[1]/Jar/Jar', 'Foo').and_return(true)
+      expect(augeas).to receive(:set).with('/foo/test[2]/Jar/Jar', 'Bar').and_return(true)
+      expect(augeas).to receive(:clearm).with('/foo/test', 'Jar/Jar').and_return(true)
+      expect(augeas).to receive(:save).and_return(false)
+      expect(provider).to receive(:print_put_errors)
+      expect(augeas).to receive(:match).and_return([])
       expect { provider.execute_changes }.to raise_error(Puppet::Error)
     end
   end
 
   describe 'when making changes', if: Puppet.features.augeas? do
     it "does not clobber the file if it's a symlink" do
-      Puppet::Util::Storage.stubs(:store)
+      allow(Puppet::Util::Storage).to receive(:store)
 
       link = tmpfile('link')
       target = tmpfile('target')
@@ -946,59 +946,59 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
   end
 
   describe 'load/save failure reporting' do
-    let(:augeas) { stub('augeas') }
+    let(:augeas) { instance_double('Augeas') }
 
     before(:each) do
-      augeas.stubs('close')
+      allow(augeas).to receive('close')
       provider.aug = augeas
     end
 
     describe 'should find load errors' do
       before(:each) do
-        augeas.expects(:match).with('/augeas//error').returns(['/augeas/files/foo/error'])
-        augeas.expects(:match).with('/augeas/files/foo/error/*').returns(['/augeas/files/foo/error/path', '/augeas/files/foo/error/message'])
-        augeas.expects(:get).with('/augeas/files/foo/error').returns('some_failure')
-        augeas.expects(:get).with('/augeas/files/foo/error/path').returns('/foo')
-        augeas.expects(:get).with('/augeas/files/foo/error/message').returns('Failed to...')
+        allow(augeas).to receive(:match).with('/augeas//error').and_return(['/augeas/files/foo/error'])
+        allow(augeas).to receive(:match).with('/augeas/files/foo/error/*').and_return(['/augeas/files/foo/error/path', '/augeas/files/foo/error/message'])
+        allow(augeas).to receive(:get).with('/augeas/files/foo/error').and_return('some_failure')
+        allow(augeas).to receive(:get).with('/augeas/files/foo/error/path').and_return('/foo')
+        allow(augeas).to receive(:get).with('/augeas/files/foo/error/message').and_return('Failed to...')
       end
 
       it 'and output only to debug when no path supplied' do
-        provider.expects(:debug).times(5)
-        provider.expects(:warning).never
+        expect(provider).to receive(:debug).exactly(5).times
+        expect(provider).to receive(:warning).never
         provider.print_load_errors(nil)
       end
 
       it 'and output a warning and to debug when path supplied' do
-        augeas.expects(:match).with('/augeas/files/foo//error').returns(['/augeas/files/foo/error'])
-        provider.expects(:warning).once
-        provider.expects(:debug).times(4)
+        expect(augeas).to receive(:match).with('/augeas/files/foo//error').and_return(['/augeas/files/foo/error'])
+        expect(provider).to receive(:warning).once
+        expect(provider).to receive(:debug).exactly(4).times
         provider.print_load_errors('/augeas/files/foo//error')
       end
 
       it "and output only to debug when path doesn't match" do
-        augeas.expects(:match).with('/augeas/files/foo//error').returns([])
-        provider.expects(:warning).never
-        provider.expects(:debug).times(5)
+        expect(augeas).to receive(:match).with('/augeas/files/foo//error').and_return([])
+        expect(provider).to receive(:warning).never
+        expect(provider).to receive(:debug).exactly(5).times
         provider.print_load_errors('/augeas/files/foo//error')
       end
     end
 
     it 'finds load errors from lenses' do
-      augeas.expects(:match).with('/augeas//error').twice.returns(['/augeas/load/Xfm/error'])
-      augeas.expects(:match).with('/augeas/load/Xfm/error/*').returns([])
-      augeas.expects(:get).with('/augeas/load/Xfm/error').returns(['Could not find lens php.aug'])
-      provider.expects(:warning).once
-      provider.expects(:debug).twice
+      expect(augeas).to receive(:match).with('/augeas//error').twice.and_return(['/augeas/load/Xfm/error'])
+      expect(augeas).to receive(:match).with('/augeas/load/Xfm/error/*').and_return([])
+      expect(augeas).to receive(:get).with('/augeas/load/Xfm/error').and_return(['Could not find lens php.aug'])
+      expect(provider).to receive(:warning).once
+      expect(provider).to receive(:debug).twice
       provider.print_load_errors('/augeas//error')
     end
 
     it 'finds save errors and output to debug' do
-      augeas.expects(:match).with("/augeas//error[. = 'put_failed']").returns(['/augeas/files/foo/error'])
-      augeas.expects(:match).with('/augeas/files/foo/error/*').returns(['/augeas/files/foo/error/path', '/augeas/files/foo/error/message'])
-      augeas.expects(:get).with('/augeas/files/foo/error').returns('some_failure')
-      augeas.expects(:get).with('/augeas/files/foo/error/path').returns('/foo')
-      augeas.expects(:get).with('/augeas/files/foo/error/message').returns('Failed to...')
-      provider.expects(:debug).times(5)
+      expect(augeas).to receive(:match).with("/augeas//error[. = 'put_failed']").and_return(['/augeas/files/foo/error'])
+      expect(augeas).to receive(:match).with('/augeas/files/foo/error/*').and_return(['/augeas/files/foo/error/path', '/augeas/files/foo/error/message'])
+      expect(augeas).to receive(:get).with('/augeas/files/foo/error').and_return('some_failure')
+      expect(augeas).to receive(:get).with('/augeas/files/foo/error/path').and_return('/foo')
+      expect(augeas).to receive(:get).with('/augeas/files/foo/error/message').and_return('Failed to...')
+      expect(provider).to receive(:debug).exactly(5).times
       provider.print_put_errors
     end
   end
@@ -1017,7 +1017,7 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
     end
 
     it 'reports load errors to debug only' do
-      provider.expects(:print_load_errors).with(nil)
+      expect(provider).to receive(:print_load_errors).with(nil)
       aug = provider.open_augeas
       expect(aug).not_to eq(nil)
     end
@@ -1027,7 +1027,7 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
       resource[:incl] = '/etc/hosts'
       resource[:lens] = 'Hosts.lns'
 
-      provider.expects(:print_load_errors).with('/augeas//error')
+      expect(provider).to receive(:print_load_errors).with('/augeas//error')
       aug = provider.open_augeas
       expect(aug).not_to eq(nil)
       expect(aug.match('/files/etc/fstab')).to eq([])
@@ -1060,7 +1060,7 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
       it 'onlies load one file if relevant context given' do
         resource[:context] = '/files/etc/fstab'
 
-        provider.expects(:print_load_errors).with('/augeas/files/etc/fstab//error')
+        expect(provider).to receive(:print_load_errors).with('/augeas/files/etc/fstab//error')
         aug = provider.open_augeas
         expect(aug).not_to eq(nil)
         expect(aug.match('/files/etc/fstab')).to eq(['/files/etc/fstab'])
@@ -1071,7 +1071,7 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
         resource[:context] = '/files/etc/test'
         resource[:load_path] = my_fixture_dir
 
-        provider.expects(:print_load_errors).with('/augeas/files/etc/test//error')
+        expect(provider).to receive(:print_load_errors).with('/augeas/files/etc/test//error')
         aug = provider.open_augeas
         expect(aug).not_to eq(nil)
         expect(aug.match('/files/etc/fstab')).to eq([])
@@ -1082,7 +1082,7 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
       it "loads standard files if context isn't specific" do
         resource[:context] = '/files/etc'
 
-        provider.expects(:print_load_errors).with(nil)
+        expect(provider).to receive(:print_load_errors).with(nil)
         aug = provider.open_augeas
         expect(aug).not_to eq(nil)
         expect(aug.match('/files/etc/fstab')).to eq(['/files/etc/fstab'])
@@ -1092,7 +1092,7 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
       it 'does not optimise if the context is a complex path' do
         resource[:context] = "/files/*[label()='etc']"
 
-        provider.expects(:print_load_errors).with(nil)
+        expect(provider).to receive(:print_load_errors).with(nil)
         aug = provider.open_augeas
         expect(aug).not_to eq(nil)
         expect(aug.match('/files/etc/fstab')).to eq(['/files/etc/fstab'])
@@ -1124,7 +1124,7 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
     context 'when running application is agent' do
       before(:each) do
         Puppet[:libdir] = my_fixture_dir
-        Puppet.run_mode.stubs(:name).returns(:agent)
+        allow(Puppet.run_mode).to receive(:name).and_return(:agent)
       end
 
       it 'offers pluginsync augeas/lenses subdir' do
@@ -1139,22 +1139,22 @@ describe Puppet::Type.type(:augeas).provider(:augeas) do
 
     context 'when running application is not agent' do
       before(:each) do
-        Puppet.run_mode.stubs(:name).returns(:user)
+        allow(Puppet.run_mode).to receive(:name).and_return(:user)
 
         env = Puppet::Node::Environment.create('root', ['/modules/foobar'])
-        Puppet.stubs(:lookup).returns(env)
-        env.stubs(:each_plugin_directory).yields('/modules/foobar')
+        allow(Puppet).to receive(:lookup).and_return(env)
+        allow(env).to receive(:each_plugin_directory).and_yield('/modules/foobar')
 
         resource[:load_path] = ['/foo', '/bar', '/baz']
       end
 
       it 'offers both load_path and module lenses path when available' do
-        File.stubs(:exist?).with('/modules/foobar/augeas/lenses').returns(true)
+        allow(File).to receive(:exist?).with('/modules/foobar/augeas/lenses').and_return(true)
         expect(provider.get_load_path(resource)).to eq('/foo:/bar:/baz:/modules/foobar/augeas/lenses')
       end
 
       it 'offers only load_path if module lenses path is not available' do
-        File.stubs(:exist?).with('/modules/foobar/augeas/lenses').returns(false)
+        allow(File).to receive(:exist?).with('/modules/foobar/augeas/lenses').and_return(false)
         expect(provider.get_load_path(resource)).to eq('/foo:/bar:/baz')
       end
     end

--- a/spec/unit/type/augeas_spec.rb
+++ b/spec/unit/type/augeas_spec.rb
@@ -16,7 +16,7 @@ describe augeas do
   describe 'basic structure' do
     it 'is able to create an instance' do
       provider_class = Puppet::Type::Augeas.provider(Puppet::Type::Augeas.providers[0])
-      Puppet::Type::Augeas.expects(:defaultprovider).returns provider_class
+      expect(Puppet::Type::Augeas).to receive(:defaultprovider).and_return provider_class
       expect(augeas.new(name: 'bar')).not_to be_nil
     end
 
@@ -59,7 +59,7 @@ describe augeas do
   describe 'default values' do
     before(:each) do
       provider_class = augeas.provider(augeas.providers[0])
-      augeas.expects(:defaultprovider).returns provider_class
+      allow(augeas).to receive(:defaultprovider).and_return provider_class
     end
 
     it 'is blank for context' do
@@ -85,15 +85,15 @@ describe augeas do
 
   describe 'provider interaction' do
     it 'returns 0 if it does not need to run' do
-      provider = stub('provider', need_to_run?: false)
-      resource = stub('resource', resource: nil, provider: provider, line: nil, file: nil)
+      provider = instance_double('Puppet::Provider::Augeas', need_to_run?: false)
+      resource = instance_double('Puppet::Type::Augeas', provider: provider, line: nil, file: nil)
       changes = augeas.attrclass(:returns).new(resource: resource)
       expect(changes.retrieve).to eq(0)
     end
 
     it 'returns :need_to_run if it needs to run' do
-      provider = stub('provider', need_to_run?: true)
-      resource = stub('resource', resource: nil, provider: provider, line: nil, file: nil)
+      provider = instance_double('Puppet::Provider::Augeas', need_to_run?: true)
+      resource = instance_double('Puppet::Type::Augeas', provider: provider, line: nil, file: nil)
       changes = augeas.attrclass(:returns).new(resource: resource)
       expect(changes.retrieve).to eq(:need_to_run)
     end
@@ -109,8 +109,8 @@ describe augeas do
     end
 
     it 'sets the context when a specific file is used' do
-      fake_provider = stub_everything 'fake_provider'
-      augeas.stubs(:defaultprovider).returns fake_provider
+      fake_provider = class_double('Puppet::Provider::Augeas')
+      allow(augeas).to receive(:defaultprovider).and_return fake_provider
       expect(augeas.new(name: :no_incl, lens: 'Hosts.lns', incl: '/etc/hosts')[:context]).to eq('/files/etc/hosts')
     end
   end


### PR DESCRIPTION
To avoid having to update this everytime we release a new agent platform, it should be enough to specify the supported OS, without
specific versions. It is assumed that for each OS in metadata.json, the versions supported are the same as what the agent itself supports.