### PR TITLE
(maint) Pin async gem

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -40,6 +40,8 @@ Gemfile:
         from_env: BEAKER_PUPPET_VERSION
         version: '~> 1.22'
       - gem: github_changelog_generator
+      - gem: async
+        version: '~> 1'
       - gem: beaker-module_install_helper
       - gem: beaker-puppet_install_helper
       - gem: nokogiri

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development do
   gem "beaker-rspec"
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1.22')
   gem "github_changelog_generator",                                              require: false
+  gem "async", '~> 1',                                                           require: false
   gem "beaker-module_install_helper",                                            require: false
   gem "beaker-puppet_install_helper",                                            require: false
   gem "nokogiri",                                                                require: false

--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,7 @@
       "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.2.0",
+  "pdk-version": "2.3.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#2.2.0",
   "template-ref": "tags/2.2.0-0-g2381db6"
 }


### PR DESCRIPTION
Async 2.0.0 requires a Ruby 3 bump, so pinning to 1.x