### PR TITLE
(maint) Fix Augeas testing failure for fedora36

### DIFF
--- a/spec/acceptance/tests/services_spec.rb
+++ b/spec/acceptance/tests/services_spec.rb
@@ -1,5 +1,10 @@
 require 'spec_helper_acceptance'
 
+# fedora36 has a malformed services entry that needs to be patched
+agents.each do |agent|
+  on(agent, 'sed -i "s/ircd,ircu3/ircd ircu3/" /etc/services') if agent.platform.include?('fedora-36')
+end
+
 RSpec.context 'Augeas services file' do
   before(:all) do
     on agents, 'cp /etc/services /tmp/services.bak'


### PR DESCRIPTION
Fedora36 has a services file with a misconfigured alias. This causes Augeas to fail
to read the file. Until this is fixed upstream lets patch around it.