### PR TITLE
feature: add frozen string magic comment

### DIFF
--- a/lib/puppet/feature/augeas.rb
+++ b/lib/puppet/feature/augeas.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'puppet/util/feature'
 
 Puppet.features.add(:augeas, libs: ['augeas'])


### PR DESCRIPTION
puppetlabs-augeas_core and puppet-augeasproviders_core both provide the augeas feature.  However the both have slightly different files (this lacking the frozen strings magic comment.  This causes puppet to perform a change on every puppet run.

This PR updates the feature in this repo to add the magic comment so both files match.  More then happy to explore alternate fixes