### PR TITLE
Remove unnecessary release prep gems

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -8,8 +8,6 @@
       Enabled: false
     Style/NumericPredicate:
       Enabled: false
-    Style/SignalException:
-      Enabled: false
     Layout/HeredocIndentation:
       Enabled: false
     Layout/LineLength:

--- a/.sync.yml
+++ b/.sync.yml
@@ -39,10 +39,6 @@ Gemfile:
       - gem: beaker-puppet
         from_env: BEAKER_PUPPET_VERSION
         version: '~> 1.22'
-      - gem: github_changelog_generator
-        version: '= 1.16.4'
-      - gem: concurrent-ruby
-        version: '= 1.1.10'
       - gem: async
         version: '~> 1'
       - gem: beaker-module_install_helper

--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,6 @@ group :development do
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1.22')
-  gem "github_changelog_generator", '= 1.16.4',                                 require: false
-  gem "concurrent-ruby", '= 1.1.10',                                            require: false
   gem "async", '~> 1',                                                          require: false
   gem "beaker-module_install_helper",                                           require: false
   gem "beaker-puppet_install_helper",                                           require: false


### PR DESCRIPTION
Previously, we added the concurrent-ruby gem in https://github.com/puppetlabs/puppetlabs-augeas_core/commit/c2e7fa274cab18db16a6f31b7506f582da83d737 to compensate for issues relating to the Docker image used for release preparation.

Since then, we have switched to piggy-backing off of the CAT team's release prep GitHub Action (see https://github.com/puppetlabs/puppetlabs-augeas_core/commit/65a59a39c353532a1a0c6fdf8dcdcc9d032f6874). That action stopped using the problematic Docker image in mid-2023 (https://github.com/puppetlabs/cat-github-actions/commit/4a83f93), so we no longer need to manage concurrent-ruby.

This also removes the github_changelog_generator gem, as it has been superceded by the gh-changelog tool to generate changelogs for releases.