### PR TITLE
Limit beaker-puppet to older Rubies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :development do
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 1.0')
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
-  gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 3.0')
+  gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 3.0') if Gem::Requirement.create('< 3.1.0').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "async", '~> 1',                                                         require: false
   gem "beaker-module_install_helper",                                          require: false
   gem "beaker-puppet_install_helper",                                          require: false


### PR DESCRIPTION
No version of beaker-puppet is compatible with Ruby >= 3.2 because of taint functions. Because beaker-puppet specifies that it cannot run on Ruby < 3.1 in its gemspec, when you run bundle install on newer Rubies- even when excluding the Gem group to which beaker-puppet belongs- Bundler errors.

This commit updates the Gemfile to only list beaker-puppet if Ruby is less than 3.1.0.